### PR TITLE
Favorites feed

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -37,6 +37,11 @@ export async function get_posts(url: string) {
       filtered.map((post) => format(post)),
     );
 
+    if (subreddit.toLowerCase() == "home") {
+      formatted = Object.values(JSON.parse(localStorage.getItem("favorite")));
+      formatted.reverse();
+    }
+
     console.log("Formatted: ", formatted.length, formatted);
     let posts: FormattedItem[] = formatted.filter(
       (v, i, a) =>


### PR DESCRIPTION
Allows users to view their favorited videos in the redditpx's own viewer, just like a regular feed.
It does so by treating /r/home in a special way (but it could be any other subreddit's name, really).